### PR TITLE
Fixed various segment prefix override ordering within the instruction parameters to compile again

### DIFF
--- a/src/protected_rings_p.asm
+++ b/src/protected_rings_p.asm
@@ -234,11 +234,11 @@ switchToRing0_2:
 	push   ebp
 	push   ebx
 	lds    ebp, [cs:ptrTSSprot]
-	mov    ebx, ds:[ebp+4]      ; Get the base
+	mov    ebx, [ds:ebp+4]      ; Get the base
 	sub    ebx, 0x10+0xC+40     ; Where we should end up in the kernel stack now
 	cmp    esp, ebx             ; Wrong kernel stack?
 	jnz    error
-	mov    ebx, ds:[ebp+8]      ; Get the stack
+	mov    ebx, [ds:ebp+8]      ; Get the stack
 	mov    bp, ss
 	cmp    bx, bp
 	jnz    error                ; Invalid kernel stack

--- a/src/test386.asm
+++ b/src/test386.asm
@@ -741,8 +741,8 @@ kernelOnlyConformingInterruptReturn:
 	push  es
 	push  ebp
 	les   ebp, [cs:ptrTSSprot]     ; Load our TSS
-	mov   word es:[ebp+0x66], 0    ; Make it available temporarily
-	mov   word es:[ebp+0xC], 0     ; Make the port available
+	mov   word [es:ebp+0x66], 0    ; Make it available temporarily
+	mov   word [es:ebp+0xC], 0     ; Make the port available
 	pop   ebp
 	pop   es
 	call  switchToRing3V86_3       ; Switch to v86 mode to test
@@ -755,7 +755,7 @@ V86IOSucceedFinish:
 	push  es
 	push  ebp
 	les   ebp, [cs:ptrTSSprot]     ; Load our TSS
-	mov   word es:[ebp+0x66], 0x68 ; Make the port unavailable again
+	mov   word [es:ebp+0x66], 0x68 ; Make the port unavailable again
 	pop   ebp
 	pop   es
 

--- a/src/tss_p.asm
+++ b/src/tss_p.asm
@@ -68,6 +68,6 @@ clearTSS:
 	push ebp
 	mov ebp,edi ;End of TSS
 	sub ebp,2 ;point to I/O map base
-	mov word es:[ebp],0x68 ;Make sure that the I/O map base is out of range to trigger faults properly!
+	mov [es:ebp],word 0x68 ;Make sure that the I/O map base is out of range to trigger faults properly!
 	pop ebp
 	ret


### PR DESCRIPTION
I've fixed some segment override prefixes that are causing nasm to complain and prevent compiling.
Basically es:[offset] vs [es:offset] parameters being changed to the latter to make it compile again.